### PR TITLE
Update MainDlg.h

### DIFF
--- a/Chapter02/SingleInstance/MainDlg.h
+++ b/Chapter02/SingleInstance/MainDlg.h
@@ -29,6 +29,6 @@ private:
 	LRESULT OnCancel(WORD /*wNotifyCode*/, WORD wID, HWND /*hWndCtl*/, BOOL& /*bHandled*/);
 
 private:
-	HANDLE m_hMutex;
+	HANDLE m_hMutex = nullptr;
 	CListBox m_List;
 };


### PR DESCRIPTION
The handle has been initialized to "nullptr", because of it defined as one of the expectations on the below in winnt.h (WinNT.h):

// begin_ntoshvp

//
// Handle to an Object
//

#ifdef STRICT
typedef void *HANDLE;
#if 0 && (_MSC_VER > 1000)
#define DECLARE_HANDLE(name) struct name##__; typedef struct name##__ *name #else
#define DECLARE_HANDLE(name) struct name##__{int unused;}; typedef struct name##__ *name #endif
#else
typedef PVOID HANDLE;
#define DECLARE_HANDLE(name) typedef HANDLE name
#endif
typedef HANDLE *PHANDLE;

// end_ntoshvp

Which also referenced from an official sources:

https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types?redirectedfrom=MSDN#:~:text=short%20HALF_PTR%3B%0A%23endif-,HANDLE,-A%20handle%20to

https://learn.microsoft.com/en-us/cpp/extensions/nullptr-cpp-component-extensions?view=msvc-170#:~:text=used%20anywhere%20a-,handle,-%2C%20native%20pointer%2C%20or