### PR TITLE
Update Injector.cpp

### DIFF
--- a/Chapter15/Injector/Injector.cpp
+++ b/Chapter15/Injector/Injector.cpp
@@ -35,6 +35,11 @@ int main(int argc, const char* argv[]) {
 	if (!hThread)
 		return Error("Failed to create remote thread");
 
+	DWORD exitCode = 0;
+	WaitForSingleObject(hThread, 5000);
+	GetExitCodeThread(hThread, &exitCode);
+	printf("LoadLibrary in remote process, returned 0x%p\n", (void*)exitCode);
+
 	printf("Thread %u created successfully!\n", tid);
 	if (WAIT_OBJECT_0 == ::WaitForSingleObject(hThread, 5000))
 		printf("Thread exited.\n");


### PR DESCRIPTION
In your sample code, it is not entirely clear to someone learning this topic whether the dll was injected  or not. Because, by looking at what is printed on the screen, they can understand that if the thread was  successfully created in the remote process, then the dll was also injected:

```
C:\>Injector.exe 12924 C:\Temp\Injected.dll
Thread 27556 created successfully!
Thread exited.
```


By adding a few lines of code to the "Injector.cpp" file, you can debug this injection, or rather, whether  the "**LoadLibraryA**" function was loaded into the remote process:

```
DWORD exitCode = 0;
GetExitCodeThread(hThread, &exitCode);
printf("LoadLibraryA in remote process, returned 0x%p\n", (void*)exitCode);

```

The 1st parameter of the "**GetExitCodeThread**" function is the handle to the thread. Since the 2nd parameter is "_LPDWORD_", we define the "exitCode" variable as a "_DWORD_" type and this is the pointer to a variable to receive the thread's termination status. Therefore, if the target process is 32-bit, "**GetExitCodeThread**"  will produce the correct result, but if it is 64-bit, "**GetExitCodeThread**" will truncate and only read the  lower 32 bits, but since we are using "**LoadLibraryA**" as the example suggests, it may be successful:

```
BOOL GetExitCodeThread(
  [in]  HANDLE  hThread,
  [out] LPDWORD lpExitCode
);
```


It is precisely because of this parameter that we can get accurate information about "**LoadLibraryA**",  because the 4th parameter of the "**CreateRemoteThread**" function is a pointer to the application-defined  function of type _LPTHREAD_START_ROUTINE_ to be executed by the thread and represents the starting address  of the thread in the remote process. The function must exist in the remote process:

```
HANDLE CreateRemoteThread(
  [in]  HANDLE                 hProcess,
  [in]  LPSECURITY_ATTRIBUTES  lpThreadAttributes,
  [in]  SIZE_T                 dwStackSize,
  [in]  LPTHREAD_START_ROUTINE lpStartAddress,
  [in]  LPVOID                 lpParameter,
  [in]  DWORD                  dwCreationFlags,
  [out] LPDWORD                lpThreadId
);
```


"**CreateRemoteThread**" is called. A new thread is created in the remote process and loads "**LoadLibraryA**".  When "**LoadLibraryA**" finishes, it returns to itself, i.e. _HMODULE_ (_NULL_ is failure). The Windows kernel stores the exit code of a thread when it exits. This "exit code" is the return value of  the thread. "**GetExitCodeThread**" reads that "exit code" stored in the kernel and writes it to the "_DWORD_" type  "_[out] LPDWORD lpExitCode_".
That is, if the start routine of the remote thread is "LoadLibraryA", then the exit code of the thread is  the return value of "**LoadLibraryA**". "**GetExitCodeThread**" returns it:

`HMODULE LoadLibraryA(LPCSTR lpLibFileName);`


However, if we pay attention, there is an error here too. Even though the "Injected123.dll" module does not exist, "**GetExitCodeThread**" returns a _non-NULL_ value. Because "**GetExitCodeThread**" is called immediately.  If the remote thread is still loading "**LoadLibraryA**", it stores "STILL_ACTIVE" in the "exit code" field of the "kernel thread" (259). That is, you do not get the actual return value, you only get the "thread is  still running" indicator.:

```
C:\>Injector.exe 19116 C:\Temp\Injected123.dll
LoadLibraryA in remote process, returned 0x0000000000000103 
Thread 27404 created successfully!
Thread exited.
```

```
C:\>Injector.exe 19116 C:\Temp\Injected.dll
LoadLibraryA in remote process, returned 0x0000000000000103 
Thread 11248 created successfully!
Thread still hanging around...

```

With this addition, it first waits for the thread to finish with "**WaitForSingleObject**":

```
DWORD exitCode = 0;
WaitForSingleObject(hThread, 5000);
GetExitCodeThread(hThread, &exitCode);
printf("LoadLibraryA in remote process, returned 0x%p\n", (void*)exitCode);
```


Therefore, "**GetExitCodeThread**" now returns the return value of "**LoadLibraryA**" (or _NULL_). As you can see,  it no longer returns a _non-NULL_ value for a module that does not exist:

```
C:\>Injector.exe 18708 C:\Temp\Injected123.dll
LoadLibrary in remote process, returned 0x0000000000000000 
Thread 11456 created successfully!
Thread exited.
```


And, we've finally reached the end, but this isn't the end:

```
C:\>Injector.exe 18708 C:\Temp\Injected.dll
LoadLibrary in remote process, returned 0x0000000000000103 
Thread 27132 created successfully!
Thread exited.
```