### PR TITLE
Create InjectorModified.cpp

### DIFF
--- a/Chapter15/Injector/InjectorModified.cpp
+++ b/Chapter15/Injector/InjectorModified.cpp
@@ -11,7 +11,7 @@ int Error(const wchar_t* msg) {
 
 bool SearchModule(DWORD pid, const wchar_t* dllName) {
     bool found = false;
-    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, pid);
+    HANDLE snap = ::CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, pid);
 
     if (snap == INVALID_HANDLE_VALUE)
         return false;
@@ -19,7 +19,7 @@ bool SearchModule(DWORD pid, const wchar_t* dllName) {
     MODULEENTRY32W me;
     me.dwSize = sizeof(me);
 
-    if (Module32FirstW(snap, &me)) {
+    if (::Module32FirstW(snap, &me)) {
         do {
 			wprintf(L"Module name: \"%s\" \n", me.szModule);
 
@@ -27,10 +27,10 @@ bool SearchModule(DWORD pid, const wchar_t* dllName) {
                 found = true;
                 // break;
             }
-        } while (Module32NextW(snap, &me));
+        } while (::Module32NextW(snap, &me));
     }
 
-    CloseHandle(snap);
+    ::CloseHandle(snap);
     return found;
 }
 

--- a/Chapter15/Injector/InjectorModified.cpp
+++ b/Chapter15/Injector/InjectorModified.cpp
@@ -1,0 +1,103 @@
+#include <Windows.h>
+#include <tlhelp32.h>
+#include <stdio.h>
+#include <wchar.h>
+
+int Error(const wchar_t* msg) {
+    wprintf(L"%s (GetLastError=%u)\n", msg, ::GetLastError());
+    return 1;
+}
+
+
+bool SearchModule(DWORD pid, const wchar_t* dllName) {
+    bool found = false;
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, pid);
+
+    if (snap == INVALID_HANDLE_VALUE)
+        return false;
+
+    MODULEENTRY32W me;
+    me.dwSize = sizeof(me);
+
+    if (Module32FirstW(snap, &me)) {
+        do {
+			wprintf(L"Module name: \"%s\" \n", me.szModule);
+
+            if (_wcsicmp(me.szModule, dllName) == 0) {
+                found = true;
+                // break;
+            }
+        } while (Module32NextW(snap, &me));
+    }
+
+    CloseHandle(snap);
+    return found;
+}
+
+
+int wmain(int argc, wchar_t* argv[]) {
+	if (argc < 3) {
+		printf("Usage: injector <pid> <dllpath>\n");
+		return 0;
+	}
+
+	DWORD pid = (DWORD)_wtoi(argv[1]);
+	const wchar_t* dllPath = argv[2];
+
+
+	HANDLE hProcess = ::OpenProcess(PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_CREATE_THREAD,
+		FALSE, pid);
+	if (!hProcess)
+		return Error(L"Failed to open process");
+
+
+	void* buffer = ::VirtualAllocEx(hProcess, nullptr, 1 << 12,
+		MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+	if (!buffer)
+		return Error(L"Failed to allocate buffer in target process");
+
+
+	if (!::WriteProcessMemory(hProcess, buffer, dllPath, (wcslen(dllPath) + 1) * sizeof(wchar_t), nullptr))
+		return Error(L"Failed to write to target process");
+
+
+	DWORD tid;
+	HANDLE hThread = ::CreateRemoteThread(hProcess, nullptr, 0,
+		(LPTHREAD_START_ROUTINE)::GetProcAddress(::GetModuleHandle(L"kernel32.dll"), "LoadLibraryW"),
+		buffer, 0, &tid);
+	if (!hThread)
+		return Error(L"Failed to create remote thread");
+
+
+	wprintf(L"Remote thread %u created succesfully, waiting for it to finish...\n", tid);
+	WaitForSingleObject(hThread, 2000);
+
+
+	const wchar_t* dllNamePtr = wcsrchr(dllPath, L'\\');
+	if (!dllNamePtr) {
+		dllNamePtr = dllPath;
+	}
+	else {
+		dllNamePtr++;
+	}
+
+
+	if (SearchModule(pid, dllNamePtr))
+		wprintf(L"Success: DLL \"%s\" loaded!\n", dllNamePtr);
+	else
+		wprintf(L"Failure: DLL \"%s\" doesn't loaded!\n", dllNamePtr);
+
+
+	if (WAIT_OBJECT_0 == ::WaitForSingleObject(hThread, 1000))
+		printf("Remote thread exited.\n");
+	else
+		printf("Remote thread still hanging around...\n");
+
+
+	::VirtualFreeEx(hProcess, buffer, 0, MEM_RELEASE);
+
+	::CloseHandle(hThread);
+	::CloseHandle(hProcess);
+
+	return 0;
+}


### PR DESCRIPTION
However, despite all the checks in previous commit, we still could not perform the check in the most optimal and correct version. For a completely clear working program, we need to use the "CreateToolhelp32Snapshot" function  from the "_#include <tlhelp32.h>_" header. It is true that functions like "**EnumProcesses**", "**WTSEnumerateProcesses(Ex)**",  etc. are used to navigate through processes in Windows to obtain different information about processes at  different levels, but since it creates a snapshot at the kernel level (although it is static) and **LoadLibraryW** -  "_HMODULE LoadLibraryW(LPCWSTR lpLibFileName);_" - (as well as **LoadLibraryA**) is loaded from "_kernel32.dll_",  it is convenient for us to use the "**CreateToolhelp32Snapshot**" function:

```
HANDLE CreateToolhelp32Snapshot(
  [in] DWORD dwFlags,
  [in] DWORD th32ProcessID
);

```

According to the assigned "_access masks_" - "**TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32**" - the "**Module32First**" function is accessed:

```
BOOL Module32First(
  [in]      HANDLE          hSnapshot,
  [in, out] LPMODULEENTRY32 lpme
);
```


and through it the "**MODULEENTRY32**" structure:

```
typedef struct tagMODULEENTRY32 {
  DWORD   dwSize;
  DWORD   th32ModuleID;
  DWORD   th32ProcessID;
  DWORD   GlblcntUsage;
  DWORD   ProccntUsage;
  BYTE    *modBaseAddr;
  DWORD   modBaseSize;
  HMODULE hModule;
  char    szModule[MAX_MODULE_NAME32 + 1];
  char    szExePath[MAX_PATH];
} MODULEENTRY32;

```

We've really reached the end:

```
C:\>Injector.exe 5360 C:\Temp\Injected.dll
Remote thread 18484 created succesfully, waiting for it to finish... Module name: "NOTEPAD.EXE"
Module name: "ntdll.dll"
Module name: "KERNEL32.DLL"
Module name: "KERNELBASE.dll"
Module name: "GDI32.dll"
Module name: "win32u.dll"
Module name: "gdi32full.dll"
Module name: "msvcp_win.dll"
Module name: "ucrtbase.dll"
Module name: "USER32.dll"
Module name: "msvcrt.dll"
Module name: "combase.dll"
Module name: "RPCRT4.dll"
Module name: "bcryptPrimitives.dll"
Module name: "shcore.dll"
Module name: "advapi32.dll"
Module name: "sechost.dll"
Module name: "COMCTL32.dll"
Module name: "IMM32.DLL"
Module name: "nvinitx.dll"
Module name: "VERSION.dll"
Module name: "Shell32.dll"
Module name: "cfgmgr32.dll"
Module name: "windows.storage.dll"
Module name: "profapi.dll"
Module name: "powrprof.dll"
Module name: "UMPDC.dll"
Module name: "shlwapi.dll"
Module name: "kernel.appcore.dll"
Module name: "cryptsp.dll"
Module name: "uxtheme.dll"
Module name: "clbcatq.dll"
Module name: "MrmCoreR.dll"
Module name: "MSCTF.dll"
Module name: "OLEAUT32.dll"
Module name: "efswrt.dll"
Module name: "MPR.dll"
Module name: "wintypes.dll"
Module name: "twinapi.appcore.dll"
Module name: "RMCLIENT.dll"
Module name: "oleacc.dll"
Module name: "TextInputFramework.dll"
Module name: "CoreUIComponents.dll"
Module name: "CoreMessaging.dll"
Module name: "ntmarta.dll"
Module name: "iertutil.dll"
Module name: "urlmon.dll"
Module name: "CRYPTBASE.DLL"
Module name: "COMDLG32.dll"
Module name: "ole32.dll"
Module name: "PROPSYS.dll"
Module name: "policymanager.dll"
Module name: "msvcp110_win.dll"
Module name: "Injected.dll"
Success: DLL "Injected.dll" loaded!
Remote thread still hanging around...
```